### PR TITLE
Tags retention API SDK Release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.6.0
+current_version = 0.7.0
 commit = True
 message = Update version {current_version} -> {new_version} [skip ci]
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,8 @@
 [![Build Status](https://v3.travis-ci.com/IBM/logs-go-sdk.svg?token=Z799xXryYYPor3yyJxEs&branch=main)](https://v3.travis.ibm.com/IBM/logs-go-sdk)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-# IBM Cloud Logs Services Go SDK 0.6.0
+# IBM Cloud Logs Services Go SDK 0.7.0
 Go client library to interact with the various [IBM Cloud Logs Services APIs](https://cloud.ibm.com/apidocs?category=logs).
-
-Disclaimer: this SDK is being released initially as a **pre-release** version.
-Changes might occur which impact applications that use this SDK.
 
 ## Table of Contents
 <!--
@@ -40,7 +37,7 @@ The IBM Cloud Logs Services Go SDK allows developers to programmatically interac
 
 Service Name | Package name 
 --- | --- 
-[logs](https://test.cloud.ibm.com/apidocs/cloud-logs-service-api/cloud-logs-v1-beta) | logsv0
+[logs](https://cloud.ibm.com/apidocs/logs-service-api) | logsv0
 
 ## Prerequisites
 
@@ -51,7 +48,7 @@ Service Name | Package name
 * Go version 1.19 or above.
 
 ## Installation
-The current version of this SDK: 0.6.0
+The current version of this SDK: 0.7.0
 
 ### Go modules  
 If your application uses Go modules for dependency management (recommended), just add an import for each service 

--- a/common/version.go
+++ b/common/version.go
@@ -17,4 +17,4 @@
 package common
 
 // Version of the SDK
-const Version = "0.6.0"
+const Version = "0.7.0"

--- a/example/v0/README.md
+++ b/example/v0/README.md
@@ -15,7 +15,7 @@ authenticator := &core.IamAuthenticator{
     ApiKey:       os.Getenv("LOGS_API_KEY"),
     ClientId:     "bx",
     ClientSecret: "bx",
-    URL:          "https://iam.test.cloud.ibm.com",
+    URL:          "https://iam.cloud.ibm.com",
 }
 ```
 

--- a/example/v0/example_v0.go
+++ b/example/v0/example_v0.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 
 	"github.com/IBM/go-sdk-core/v5/core"
-	"github.com/go-openapi/strfmt"
 	"github.com/IBM/logs-go-sdk/logsv0"
+	"github.com/go-openapi/strfmt"
 )
 
 func getRandomName() string {
@@ -26,7 +26,7 @@ func main() {
 		ApiKey:       os.Getenv("LOGS_API_KEY"),
 		ClientId:     "bx",
 		ClientSecret: "bx",
-		URL:          "https://iam.test.cloud.ibm.com",
+		URL:          "https://iam.cloud.ibm.com",
 	}
 
 	// Initialize the service options.

--- a/logsv0/logs_v0.go
+++ b/logsv0/logs_v0.go
@@ -3746,6 +3746,133 @@ func (logs *LogsV0) DeleteViewFolderWithContext(ctx context.Context, deleteViewF
 	return
 }
 
+// GetLogDataRetentionTags : Get log data retention tags
+// Get log data retention tags. Returns 404 if retention tags have not been activated.
+func (logs *LogsV0) GetLogDataRetentionTags(getLogDataRetentionTagsOptions *GetLogDataRetentionTagsOptions) (result *LogDataRetentionTags, response *core.DetailedResponse, err error) {
+	result, response, err = logs.GetLogDataRetentionTagsWithContext(context.Background(), getLogDataRetentionTagsOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// GetLogDataRetentionTagsWithContext is an alternate form of the GetLogDataRetentionTags method which supports a Context parameter
+func (logs *LogsV0) GetLogDataRetentionTagsWithContext(ctx context.Context, getLogDataRetentionTagsOptions *GetLogDataRetentionTagsOptions) (result *LogDataRetentionTags, response *core.DetailedResponse, err error) {
+	err = core.ValidateStruct(getLogDataRetentionTagsOptions, "getLogDataRetentionTagsOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.GET)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = logs.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(logs.Service.Options.URL, `/v1/log_data_retention_tags`, nil)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range getLogDataRetentionTagsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("logs", "V0", "GetLogDataRetentionTags")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Accept", "application/json")
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	var rawResponse map[string]json.RawMessage
+	response, err = logs.Service.Request(request, &rawResponse)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "get_log_data_retention_tags", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+	if rawResponse != nil {
+		err = core.UnmarshalModel(rawResponse, "", &result, UnmarshalLogDataRetentionTags)
+		if err != nil {
+			err = core.SDKErrorf(err, "", "unmarshal-resp-error", common.GetComponentInfo())
+			return
+		}
+		response.Result = result
+	}
+
+	return
+}
+
+// UpdateLogDataRetentionTags : Update log data retention tags
+// Update log data retention tags. If retention tags have not been activated yet, the first successful PUT request will
+// activate them. An archive bucket must be configured before retention tags can be activated.
+func (logs *LogsV0) UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptions *UpdateLogDataRetentionTagsOptions) (response *core.DetailedResponse, err error) {
+	response, err = logs.UpdateLogDataRetentionTagsWithContext(context.Background(), updateLogDataRetentionTagsOptions)
+	err = core.RepurposeSDKProblem(err, "")
+	return
+}
+
+// UpdateLogDataRetentionTagsWithContext is an alternate form of the UpdateLogDataRetentionTags method which supports a Context parameter
+func (logs *LogsV0) UpdateLogDataRetentionTagsWithContext(ctx context.Context, updateLogDataRetentionTagsOptions *UpdateLogDataRetentionTagsOptions) (response *core.DetailedResponse, err error) {
+	err = core.ValidateNotNil(updateLogDataRetentionTagsOptions, "updateLogDataRetentionTagsOptions cannot be nil")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "unexpected-nil-param", common.GetComponentInfo())
+		return
+	}
+	err = core.ValidateStruct(updateLogDataRetentionTagsOptions, "updateLogDataRetentionTagsOptions")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "struct-validation-error", common.GetComponentInfo())
+		return
+	}
+
+	builder := core.NewRequestBuilder(core.PUT)
+	builder = builder.WithContext(ctx)
+	builder.EnableGzipCompression = logs.GetEnableGzipCompression()
+	_, err = builder.ResolveRequestURL(logs.Service.Options.URL, `/v1/log_data_retention_tags`, nil)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "url-resolve-error", common.GetComponentInfo())
+		return
+	}
+
+	for headerName, headerValue := range updateLogDataRetentionTagsOptions.Headers {
+		builder.AddHeader(headerName, headerValue)
+	}
+
+	sdkHeaders := common.GetSdkHeaders("logs", "V0", "UpdateLogDataRetentionTags")
+	for headerName, headerValue := range sdkHeaders {
+		builder.AddHeader(headerName, headerValue)
+	}
+	builder.AddHeader("Content-Type", "application/json")
+
+	body := make(map[string]interface{})
+	if updateLogDataRetentionTagsOptions.Tags != nil {
+		body["tags"] = updateLogDataRetentionTagsOptions.Tags
+	}
+	_, err = builder.SetBodyContentJSON(body)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "set-json-body-error", common.GetComponentInfo())
+		return
+	}
+
+	request, err := builder.Build()
+	if err != nil {
+		err = core.SDKErrorf(err, "", "build-error", common.GetComponentInfo())
+		return
+	}
+
+	response, err = logs.Service.Request(request, nil)
+	if err != nil {
+		core.EnrichHTTPProblem(err, "update_log_data_retention_tags", getServiceComponentInfo())
+		err = core.SDKErrorf(err, "", "http-request-err", common.GetComponentInfo())
+		return
+	}
+
+	return
+}
+
 // ListOutgoingWebhooks : List Outbound Integrations
 // List Outbound Integrations.
 func (logs *LogsV0) ListOutgoingWebhooks(listOutgoingWebhooksOptions *ListOutgoingWebhooksOptions) (result *OutgoingWebhookCollection, response *core.DetailedResponse, err error) {
@@ -20723,6 +20850,24 @@ func (options *GetExtensionsOptions) SetHeaders(param map[string]string) *GetExt
 	return options
 }
 
+// GetLogDataRetentionTagsOptions : The GetLogDataRetentionTags options.
+type GetLogDataRetentionTagsOptions struct {
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewGetLogDataRetentionTagsOptions : Instantiate GetLogDataRetentionTagsOptions
+func (*LogsV0) NewGetLogDataRetentionTagsOptions() *GetLogDataRetentionTagsOptions {
+	return &GetLogDataRetentionTagsOptions{}
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *GetLogDataRetentionTagsOptions) SetHeaders(param map[string]string) *GetLogDataRetentionTagsOptions {
+	options.Headers = param
+	return options
+}
+
 // GetOutgoingWebhookOptions : The GetOutgoingWebhook options.
 type GetOutgoingWebhookOptions struct {
 	// The ID of the outbound integration to delete.
@@ -21066,6 +21211,37 @@ func (*LogsV0) NewListViewsOptions() *ListViewsOptions {
 func (options *ListViewsOptions) SetHeaders(param map[string]string) *ListViewsOptions {
 	options.Headers = param
 	return options
+}
+
+// LogDataRetentionTags : Log data retention tags configuration. Manages the three editable archive retention tags used for log retention
+// policies. The 'Default' tag is system-managed and cannot be modified through this API.
+type LogDataRetentionTags struct {
+	// List of editable archive retention tags, excluding non-editable tags such as Default.
+	Tags []string `json:"tags" validate:"required"`
+}
+
+// NewLogDataRetentionTags : Instantiate LogDataRetentionTags (Generic Model Constructor)
+func (*LogsV0) NewLogDataRetentionTags(tags []string) (_model *LogDataRetentionTags, err error) {
+	_model = &LogDataRetentionTags{
+		Tags: tags,
+	}
+	err = core.ValidateStruct(_model, "required parameters")
+	if err != nil {
+		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
+	}
+	return
+}
+
+// UnmarshalLogDataRetentionTags unmarshals an instance of LogDataRetentionTags from the specified map of raw messages.
+func UnmarshalLogDataRetentionTags(m map[string]json.RawMessage, result interface{}) (err error) {
+	obj := new(LogDataRetentionTags)
+	err = core.UnmarshalPrimitive(m, "tags", &obj.Tags)
+	if err != nil {
+		err = core.SDKErrorf(err, "", "tags-error", common.GetComponentInfo())
+		return
+	}
+	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
+	return
 }
 
 // OutgoingWebhook : The outbound integration.
@@ -21437,8 +21613,8 @@ type Policy struct {
 	// Updated at date at utc+0.
 	UpdatedAt *string `json:"updated_at" validate:"required"`
 
-	// Archive retention definition.
-	ArchiveRetention *QuotaV1ArchiveRetention `json:"archive_retention,omitempty"`
+	// Archive retention tag. Required when retention tags are active. Cannot be set when retention tags are not active.
+	ArchiveRetentionTag *string `json:"archive_retention_tag,omitempty"`
 
 	// Log rules.
 	LogRules *QuotaV1LogRules `json:"log_rules,omitempty"`
@@ -21529,9 +21705,9 @@ func UnmarshalPolicy(m map[string]json.RawMessage, result interface{}) (err erro
 		err = core.SDKErrorf(err, "", "updated_at-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalModel(m, "archive_retention", &obj.ArchiveRetention, UnmarshalQuotaV1ArchiveRetention)
+	err = core.UnmarshalPrimitive(m, "archive_retention_tag", &obj.ArchiveRetentionTag)
 	if err != nil {
-		err = core.SDKErrorf(err, "", "archive_retention-error", common.GetComponentInfo())
+		err = core.SDKErrorf(err, "", "archive_retention_tag-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalModel(m, "log_rules", &obj.LogRules, UnmarshalQuotaV1LogRules)
@@ -21644,8 +21820,8 @@ type PolicyPrototype struct {
 	// Rule for matching the application name.
 	SubsystemRule *QuotaV1Rule `json:"subsystem_rule,omitempty"`
 
-	// Archive retention definition.
-	ArchiveRetention *QuotaV1ArchiveRetention `json:"archive_retention,omitempty"`
+	// Archive retention tag. Required when retention tags are active. Cannot be set when retention tags are not active.
+	ArchiveRetentionTag *string `json:"archive_retention_tag,omitempty"`
 
 	// Flag to enable or disable a policy. This flag is supported only while updating a policy, since the policies are
 	// always enabled during creation.
@@ -21705,9 +21881,9 @@ func UnmarshalPolicyPrototype(m map[string]json.RawMessage, result interface{}) 
 		err = core.SDKErrorf(err, "", "subsystem_rule-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalModel(m, "archive_retention", &obj.ArchiveRetention, UnmarshalQuotaV1ArchiveRetention)
+	err = core.UnmarshalPrimitive(m, "archive_retention_tag", &obj.ArchiveRetentionTag)
 	if err != nil {
-		err = core.SDKErrorf(err, "", "archive_retention-error", common.GetComponentInfo())
+		err = core.SDKErrorf(err, "", "archive_retention_tag-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enabled", &obj.Enabled)
@@ -21718,36 +21894,6 @@ func UnmarshalPolicyPrototype(m map[string]json.RawMessage, result interface{}) 
 	err = core.UnmarshalModel(m, "log_rules", &obj.LogRules, UnmarshalQuotaV1LogRules)
 	if err != nil {
 		err = core.SDKErrorf(err, "", "log_rules-error", common.GetComponentInfo())
-		return
-	}
-	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
-	return
-}
-
-// QuotaV1ArchiveRetention : Archive retention definition.
-type QuotaV1ArchiveRetention struct {
-	// ID of the archive retention definition.
-	ID *strfmt.UUID `json:"id" validate:"required"`
-}
-
-// NewQuotaV1ArchiveRetention : Instantiate QuotaV1ArchiveRetention (Generic Model Constructor)
-func (*LogsV0) NewQuotaV1ArchiveRetention(id *strfmt.UUID) (_model *QuotaV1ArchiveRetention, err error) {
-	_model = &QuotaV1ArchiveRetention{
-		ID: id,
-	}
-	err = core.ValidateStruct(_model, "required parameters")
-	if err != nil {
-		err = core.SDKErrorf(err, "", "model-missing-required", common.GetComponentInfo())
-	}
-	return
-}
-
-// UnmarshalQuotaV1ArchiveRetention unmarshals an instance of QuotaV1ArchiveRetention from the specified map of raw messages.
-func UnmarshalQuotaV1ArchiveRetention(m map[string]json.RawMessage, result interface{}) (err error) {
-	obj := new(QuotaV1ArchiveRetention)
-	err = core.UnmarshalPrimitive(m, "id", &obj.ID)
-	if err != nil {
-		err = core.SDKErrorf(err, "", "id-error", common.GetComponentInfo())
 		return
 	}
 	reflect.ValueOf(result).Elem().Set(reflect.ValueOf(obj))
@@ -21767,7 +21913,6 @@ const (
 	QuotaV1LogRules_Severities_Debug = "debug"
 	QuotaV1LogRules_Severities_Error = "error"
 	QuotaV1LogRules_Severities_Info = "info"
-	QuotaV1LogRules_Severities_Unspecified = "unspecified"
 	QuotaV1LogRules_Severities_Verbose = "verbose"
 	QuotaV1LogRules_Severities_Warning = "warning"
 )
@@ -23795,6 +23940,34 @@ func (_options *UpdateExtensionDeploymentOptions) SetSubsystems(subsystems []str
 
 // SetHeaders : Allow user to set Headers
 func (options *UpdateExtensionDeploymentOptions) SetHeaders(param map[string]string) *UpdateExtensionDeploymentOptions {
+	options.Headers = param
+	return options
+}
+
+// UpdateLogDataRetentionTagsOptions : The UpdateLogDataRetentionTags options.
+type UpdateLogDataRetentionTagsOptions struct {
+	// List of editable archive retention tags, excluding non-editable tags such as Default.
+	Tags []string `json:"tags" validate:"required"`
+
+	// Allows users to set headers on API requests.
+	Headers map[string]string
+}
+
+// NewUpdateLogDataRetentionTagsOptions : Instantiate UpdateLogDataRetentionTagsOptions
+func (*LogsV0) NewUpdateLogDataRetentionTagsOptions(tags []string) *UpdateLogDataRetentionTagsOptions {
+	return &UpdateLogDataRetentionTagsOptions{
+		Tags: tags,
+	}
+}
+
+// SetTags : Allow user to set Tags
+func (_options *UpdateLogDataRetentionTagsOptions) SetTags(tags []string) *UpdateLogDataRetentionTagsOptions {
+	_options.Tags = tags
+	return _options
+}
+
+// SetHeaders : Allow user to set Headers
+func (options *UpdateLogDataRetentionTagsOptions) SetHeaders(param map[string]string) *UpdateLogDataRetentionTagsOptions {
 	options.Headers = param
 	return options
 }
@@ -31454,7 +31627,8 @@ type PolicyPrototypeQuotaV1CreatePolicyRequestSourceTypeRulesLogRules struct {
 
 	SubsystemRule *QuotaV1Rule `json:"subsystem_rule,omitempty"`
 
-	ArchiveRetention *QuotaV1ArchiveRetention `json:"archive_retention,omitempty"`
+	// Archive retention tag. Required when retention tags are active. Cannot be set when retention tags are not active.
+	ArchiveRetentionTag *string `json:"archive_retention_tag,omitempty"`
 
 	// Flag to enable or disable a policy. This flag is supported only while updating a policy, since the policies are
 	// always enabled during creation.
@@ -31524,9 +31698,9 @@ func UnmarshalPolicyPrototypeQuotaV1CreatePolicyRequestSourceTypeRulesLogRules(m
 		err = core.SDKErrorf(err, "", "subsystem_rule-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalModel(m, "archive_retention", &obj.ArchiveRetention, UnmarshalQuotaV1ArchiveRetention)
+	err = core.UnmarshalPrimitive(m, "archive_retention_tag", &obj.ArchiveRetentionTag)
 	if err != nil {
-		err = core.SDKErrorf(err, "", "archive_retention-error", common.GetComponentInfo())
+		err = core.SDKErrorf(err, "", "archive_retention_tag-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalPrimitive(m, "enabled", &obj.Enabled)
@@ -31583,7 +31757,8 @@ type PolicyQuotaV1PolicySourceTypeRulesLogRules struct {
 	// Updated at date at utc+0.
 	UpdatedAt *string `json:"updated_at" validate:"required"`
 
-	ArchiveRetention *QuotaV1ArchiveRetention `json:"archive_retention,omitempty"`
+	// Archive retention tag. Required when retention tags are active. Cannot be set when retention tags are not active.
+	ArchiveRetentionTag *string `json:"archive_retention_tag,omitempty"`
 
 	// Log rules.
 	LogRules *QuotaV1LogRules `json:"log_rules,omitempty"`
@@ -31671,9 +31846,9 @@ func UnmarshalPolicyQuotaV1PolicySourceTypeRulesLogRules(m map[string]json.RawMe
 		err = core.SDKErrorf(err, "", "updated_at-error", common.GetComponentInfo())
 		return
 	}
-	err = core.UnmarshalModel(m, "archive_retention", &obj.ArchiveRetention, UnmarshalQuotaV1ArchiveRetention)
+	err = core.UnmarshalPrimitive(m, "archive_retention_tag", &obj.ArchiveRetentionTag)
 	if err != nil {
-		err = core.SDKErrorf(err, "", "archive_retention-error", common.GetComponentInfo())
+		err = core.SDKErrorf(err, "", "archive_retention_tag-error", common.GetComponentInfo())
 		return
 	}
 	err = core.UnmarshalModel(m, "log_rules", &obj.LogRules, UnmarshalQuotaV1LogRules)

--- a/logsv0/logs_v0_examples_test.go
+++ b/logsv0/logs_v0_examples_test.go
@@ -1572,6 +1572,45 @@ var _ = Describe(`LogsV0 Examples Tests`, func() {
 			Expect(response.StatusCode).To(Equal(200))
 			Expect(viewFolder).ToNot(BeNil())
 		})
+		It(`GetLogDataRetentionTags request example`, func() {
+			fmt.Println("\nGetLogDataRetentionTags() result:")
+			// begin-get_log_data_retention_tags
+
+			getLogDataRetentionTagsOptions := logsService.NewGetLogDataRetentionTagsOptions()
+
+			logDataRetentionTags, response, err := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptions)
+			if err != nil {
+				panic(err)
+			}
+			b, _ := json.MarshalIndent(logDataRetentionTags, "", "  ")
+			fmt.Println(string(b))
+
+			// end-get_log_data_retention_tags
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(200))
+			Expect(logDataRetentionTags).ToNot(BeNil())
+		})
+		It(`UpdateLogDataRetentionTags request example`, func() {
+			// begin-update_log_data_retention_tags
+
+			updateLogDataRetentionTagsOptions := logsService.NewUpdateLogDataRetentionTagsOptions(
+				[]string{"Short", "Intermediate", "Long"},
+			)
+
+			response, err := logsService.UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptions)
+			if err != nil {
+				panic(err)
+			}
+			if response.StatusCode != 204 {
+				fmt.Printf("\nUnexpected response status code received from UpdateLogDataRetentionTags(): %d\n", response.StatusCode)
+			}
+
+			// end-update_log_data_retention_tags
+
+			Expect(err).To(BeNil())
+			Expect(response.StatusCode).To(Equal(204))
+		})
 		It(`ListOutgoingWebhooks request example`, func() {
 			fmt.Println("\nListOutgoingWebhooks() result:")
 			// begin-list_outgoing_webhooks

--- a/logsv0/logs_v0_integration_test.go
+++ b/logsv0/logs_v0_integration_test.go
@@ -1108,6 +1108,47 @@ var _ = Describe(`LogsV0 Integration Tests`, func() {
 		})
 	})
 
+	Describe(`GetLogDataRetentionTags - Get log data retention tags`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`GetLogDataRetentionTags(getLogDataRetentionTagsOptions *GetLogDataRetentionTagsOptions)`, func() {
+			getLogDataRetentionTagsOptions := &logsv0.GetLogDataRetentionTagsOptions{}
+
+			logDataRetentionTags, response, err := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptions)
+			// 404 is expected if retention tags have not been activated yet
+			if response.StatusCode == 404 {
+				Expect(err).ToNot(BeNil())
+				fmt.Fprintf(GinkgoWriter, "Log data retention tags not activated (404), skipping validation\n")
+			} else {
+				Expect(err).To(BeNil())
+				Expect(response.StatusCode).To(Equal(200))
+				Expect(logDataRetentionTags).ToNot(BeNil())
+			}
+		})
+	})
+
+	Describe(`UpdateLogDataRetentionTags - Update log data retention tags`, func() {
+		BeforeEach(func() {
+			shouldSkipTest()
+		})
+		It(`UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptions *UpdateLogDataRetentionTagsOptions)`, func() {
+			updateLogDataRetentionTagsOptions := &logsv0.UpdateLogDataRetentionTagsOptions{
+				Tags: []string{"Short", "Intermediate", "Long"},
+			}
+
+			response, err := logsService.UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptions)
+			// 404 is expected if retention tags have not been activated yet or archive bucket not configured
+			if response.StatusCode == 404 {
+				Expect(err).ToNot(BeNil())
+				fmt.Fprintf(GinkgoWriter, "Log data retention tags not activated or archive bucket not configured (404), skipping validation\n")
+			} else {
+				Expect(err).To(BeNil())
+				Expect(response.StatusCode).To(Equal(204))
+			}
+		})
+	})
+
 	Describe(`ListOutgoingWebhooks - List Outbound Integrations`, func() {
 		BeforeEach(func() {
 			shouldSkipTest()

--- a/logsv0/logs_v0_test.go
+++ b/logsv0/logs_v0_test.go
@@ -14722,6 +14722,290 @@ var _ = Describe(`LogsV0`, func() {
 			})
 		})
 	})
+	Describe(`GetLogDataRetentionTags(getLogDataRetentionTagsOptions *GetLogDataRetentionTagsOptions) - Operation response error`, func() {
+		getLogDataRetentionTagsPath := "/v1/log_data_retention_tags"
+		Context(`Using mock server endpoint with invalid JSON response`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLogDataRetentionTagsPath))
+					Expect(req.Method).To(Equal("GET"))
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprint(res, `} this is not valid json {`)
+				}))
+			})
+			It(`Invoke GetLogDataRetentionTags with error: Operation response processing error`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := new(logsv0.GetLogDataRetentionTagsOptions)
+				getLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Expect response parsing to fail since we are receiving a text/plain response
+				result, response, operationErr := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+
+				// Enable retries and test again
+				logsService.EnableRetries(0, 0)
+				result, response, operationErr = logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`GetLogDataRetentionTags(getLogDataRetentionTagsOptions *GetLogDataRetentionTagsOptions)`, func() {
+		getLogDataRetentionTagsPath := "/v1/log_data_retention_tags"
+		Context(`Using mock server endpoint with timeout`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLogDataRetentionTagsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Sleep a short time to support a timeout test
+					time.Sleep(100 * time.Millisecond)
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"tags": ["Tags"]}`)
+				}))
+			})
+			It(`Invoke GetLogDataRetentionTags successfully with retries`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+				logsService.EnableRetries(0, 0)
+
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := new(logsv0.GetLogDataRetentionTagsOptions)
+				getLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with a Context to test a timeout error
+				ctx, cancelFunc := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc()
+				_, _, operationErr := logsService.GetLogDataRetentionTagsWithContext(ctx, getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+
+				// Disable retries and test again
+				logsService.DisableRetries()
+				result, response, operationErr := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+				// Re-test the timeout error with retries disabled
+				ctx, cancelFunc2 := context.WithTimeout(context.Background(), 80*time.Millisecond)
+				defer cancelFunc2()
+				_, _, operationErr = logsService.GetLogDataRetentionTagsWithContext(ctx, getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring("deadline exceeded"))
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(getLogDataRetentionTagsPath))
+					Expect(req.Method).To(Equal("GET"))
+
+					// Set mock response
+					res.Header().Set("Content-type", "application/json")
+					res.WriteHeader(200)
+					fmt.Fprintf(res, "%s", `{"tags": ["Tags"]}`)
+				}))
+			})
+			It(`Invoke GetLogDataRetentionTags successfully`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				result, response, operationErr := logsService.GetLogDataRetentionTags(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := new(logsv0.GetLogDataRetentionTagsOptions)
+				getLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				result, response, operationErr = logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+				Expect(result).ToNot(BeNil())
+
+			})
+			It(`Invoke GetLogDataRetentionTags with error: Operation request error`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := new(logsv0.GetLogDataRetentionTagsOptions)
+				getLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := logsService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				result, response, operationErr := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+		Context(`Using mock server endpoint with missing response body`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Set success status code with no respoonse body
+					res.WriteHeader(200)
+				}))
+			})
+			It(`Invoke GetLogDataRetentionTags successfully`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := new(logsv0.GetLogDataRetentionTagsOptions)
+				getLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation
+				result, response, operationErr := logsService.GetLogDataRetentionTags(getLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+
+				// Verify a nil result
+				Expect(result).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
+	Describe(`UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptions *UpdateLogDataRetentionTagsOptions)`, func() {
+		updateLogDataRetentionTagsPath := "/v1/log_data_retention_tags"
+		Context(`Using mock server endpoint`, func() {
+			BeforeEach(func() {
+				testServer = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+					defer GinkgoRecover()
+
+					// Verify the contents of the request
+					Expect(req.URL.EscapedPath()).To(Equal(updateLogDataRetentionTagsPath))
+					Expect(req.Method).To(Equal("PUT"))
+
+					// For gzip-disabled operation, verify Content-Encoding is not set.
+					Expect(req.Header.Get("Content-Encoding")).To(BeEmpty())
+
+					// If there is a body, then make sure we can read it
+					bodyBuf := new(bytes.Buffer)
+					if req.Header.Get("Content-Encoding") == "gzip" {
+						body, err := core.NewGzipDecompressionReader(req.Body)
+						Expect(err).To(BeNil())
+						_, err = bodyBuf.ReadFrom(body)
+						Expect(err).To(BeNil())
+					} else {
+						_, err := bodyBuf.ReadFrom(req.Body)
+						Expect(err).To(BeNil())
+					}
+					fmt.Fprintf(GinkgoWriter, "  Request body: %s", bodyBuf.String())
+
+					res.WriteHeader(204)
+				}))
+			})
+			It(`Invoke UpdateLogDataRetentionTags successfully`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Invoke operation with nil options model (negative test)
+				response, operationErr := logsService.UpdateLogDataRetentionTags(nil)
+				Expect(operationErr).NotTo(BeNil())
+				Expect(response).To(BeNil())
+
+				// Construct an instance of the UpdateLogDataRetentionTagsOptions model
+				updateLogDataRetentionTagsOptionsModel := new(logsv0.UpdateLogDataRetentionTagsOptions)
+				updateLogDataRetentionTagsOptionsModel.Tags = []string{"Short", "Intermediate", "Long"}
+				updateLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+
+				// Invoke operation with valid options model (positive test)
+				response, operationErr = logsService.UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).To(BeNil())
+				Expect(response).ToNot(BeNil())
+			})
+			It(`Invoke UpdateLogDataRetentionTags with error: Operation validation and request error`, func() {
+				logsService, serviceErr := logsv0.NewLogsV0(&logsv0.LogsV0Options{
+					URL:           testServer.URL,
+					Authenticator: &core.NoAuthAuthenticator{},
+				})
+				Expect(serviceErr).To(BeNil())
+				Expect(logsService).ToNot(BeNil())
+
+				// Construct an instance of the UpdateLogDataRetentionTagsOptions model
+				updateLogDataRetentionTagsOptionsModel := new(logsv0.UpdateLogDataRetentionTagsOptions)
+				updateLogDataRetentionTagsOptionsModel.Tags = []string{"Short", "Intermediate", "Long"}
+				updateLogDataRetentionTagsOptionsModel.Headers = map[string]string{"x-custom-header": "x-custom-value"}
+				// Invoke operation with empty URL (negative test)
+				err := logsService.SetServiceURL("")
+				Expect(err).To(BeNil())
+				response, operationErr := logsService.UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptionsModel)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(operationErr.Error()).To(ContainSubstring(core.ERRORMSG_SERVICE_URL_MISSING))
+				Expect(response).To(BeNil())
+				// Construct a second instance of the UpdateLogDataRetentionTagsOptions model with no property values
+				updateLogDataRetentionTagsOptionsModelNew := new(logsv0.UpdateLogDataRetentionTagsOptions)
+				// Invoke operation with invalid model (negative test)
+				response, operationErr = logsService.UpdateLogDataRetentionTags(updateLogDataRetentionTagsOptionsModelNew)
+				Expect(operationErr).ToNot(BeNil())
+				Expect(response).To(BeNil())
+			})
+			AfterEach(func() {
+				testServer.Close()
+			})
+		})
+	})
 	Describe(`ListOutgoingWebhooks(listOutgoingWebhooksOptions *ListOutgoingWebhooksOptions) - Operation response error`, func() {
 		listOutgoingWebhooksPath := "/v1/outgoing_webhooks"
 		Context(`Using mock server endpoint with invalid JSON response`, func() {
@@ -15915,7 +16199,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke GetPolicy successfully with retries`, func() {
@@ -15969,7 +16253,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke GetPolicy successfully`, func() {
@@ -16097,10 +16381,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16113,7 +16393,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16173,7 +16453,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke UpdatePolicy successfully with retries`, func() {
@@ -16194,10 +16474,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16210,7 +16486,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16273,7 +16549,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke UpdatePolicy successfully`, func() {
@@ -16299,10 +16575,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16315,7 +16587,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16349,10 +16621,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16365,7 +16633,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16420,10 +16688,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16436,7 +16700,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16594,7 +16858,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policies": [{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}]}`)
+					fmt.Fprintf(res, "%s", `{"policies": [{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}]}`)
 				}))
 			})
 			It(`Invoke GetCompanyPolicies successfully with retries`, func() {
@@ -16651,7 +16915,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(200)
-					fmt.Fprintf(res, "%s", `{"policies": [{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}]}`)
+					fmt.Fprintf(res, "%s", `{"policies": [{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}]}`)
 				}))
 			})
 			It(`Invoke GetCompanyPolicies successfully`, func() {
@@ -16775,10 +17039,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16791,7 +17051,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16850,7 +17110,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke CreatePolicy successfully with retries`, func() {
@@ -16871,10 +17131,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16887,7 +17143,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -16949,7 +17205,7 @@ var _ = Describe(`LogsV0`, func() {
 					// Set mock response
 					res.Header().Set("Content-type", "application/json")
 					res.WriteHeader(201)
-					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f"}, "log_rules": {"severities": ["critical"]}}`)
+					fmt.Fprintf(res, "%s", `{"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "before": {"id": "3dc02998-0b50-4ea8-b68a-4779d716fa1f", "name": "My Policy"}, "company_id": 1234, "name": "Policy Name", "description": "Policy description", "priority": "type_high", "deleted": true, "enabled": true, "order": 1, "application_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "subsystem_rule": {"rule_type_id": "includes", "name": "Rule Name"}, "created_at": "2023-06-21 14:24:39", "updated_at": "2023-06-21 14:24:39", "archive_retention_tag": "Default", "log_rules": {"severities": ["critical"]}}`)
 				}))
 			})
 			It(`Invoke CreatePolicy successfully`, func() {
@@ -16975,10 +17231,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -16991,7 +17243,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -17024,10 +17276,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -17040,7 +17288,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -17094,10 +17342,6 @@ var _ = Describe(`LogsV0`, func() {
 				quotaV1RuleModel.RuleTypeID = core.StringPtr("is")
 				quotaV1RuleModel.Name = core.StringPtr("policy-test")
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				quotaV1LogRulesModel.Severities = []string{"debug", "verbose", "info", "warning", "error"}
@@ -17110,7 +17354,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 
@@ -22258,12 +22502,6 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(quotaV1RuleModel.RuleTypeID).To(Equal(core.StringPtr("includes")))
 				Expect(quotaV1RuleModel.Name).To(Equal(core.StringPtr("Rule Name")))
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				Expect(quotaV1ArchiveRetentionModel).ToNot(BeNil())
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-				Expect(quotaV1ArchiveRetentionModel.ID).To(Equal(CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")))
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				Expect(quotaV1LogRulesModel).ToNot(BeNil())
@@ -22279,7 +22517,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 				Expect(policyPrototypeModel.Name).To(Equal(core.StringPtr("My Policy")))
@@ -22288,7 +22526,7 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(policyPrototypeModel.Priority).To(Equal(core.StringPtr("type_high")))
 				Expect(policyPrototypeModel.ApplicationRule).To(Equal(quotaV1RuleModel))
 				Expect(policyPrototypeModel.SubsystemRule).To(Equal(quotaV1RuleModel))
-				Expect(policyPrototypeModel.ArchiveRetention).To(Equal(quotaV1ArchiveRetentionModel))
+				Expect(policyPrototypeModel.ArchiveRetentionTag).To(Equal(core.StringPtr("Default")))
 				Expect(policyPrototypeModel.Enabled).To(Equal(core.BoolPtr(true)))
 				Expect(policyPrototypeModel.LogRules).To(Equal(quotaV1LogRulesModel))
 
@@ -22736,6 +22974,13 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(getExtensionsOptionsModel.Deployed).To(Equal(core.BoolPtr(true)))
 				Expect(getExtensionsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewGetLogDataRetentionTagsOptions successfully`, func() {
+				// Construct an instance of the GetLogDataRetentionTagsOptions model
+				getLogDataRetentionTagsOptionsModel := logsService.NewGetLogDataRetentionTagsOptions()
+				getLogDataRetentionTagsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(getLogDataRetentionTagsOptionsModel).ToNot(BeNil())
+				Expect(getLogDataRetentionTagsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewGetOutgoingWebhookOptions successfully`, func() {
 				// Construct an instance of the GetOutgoingWebhookOptions model
 				id := CreateMockUUID("585bea36-bdd1-4bfb-9a26-51f1f8a12660")
@@ -22853,6 +23098,12 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(listViewsOptionsModel).ToNot(BeNil())
 				Expect(listViewsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewLogDataRetentionTags successfully`, func() {
+				tags := []string{"Short", "Intermediate", "Long"}
+				_model, err := logsService.NewLogDataRetentionTags(tags)
+				Expect(_model).ToNot(BeNil())
+				Expect(err).To(BeNil())
+			})
 			It(`Invoke NewOutgoingWebhooksV1IbmEventNotificationsConfig successfully`, func() {
 				eventNotificationsInstanceID := CreateMockUUID("585bea36-bdd1-4bfb-9a26-51f1f8a12660")
 				regionID := "eu-es"
@@ -22873,12 +23124,6 @@ var _ = Describe(`LogsV0`, func() {
 			It(`Invoke NewPolicyBeforePrototype successfully`, func() {
 				id := CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
 				_model, err := logsService.NewPolicyBeforePrototype(id)
-				Expect(_model).ToNot(BeNil())
-				Expect(err).To(BeNil())
-			})
-			It(`Invoke NewQuotaV1ArchiveRetention successfully`, func() {
-				id := CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-				_model, err := logsService.NewQuotaV1ArchiveRetention(id)
 				Expect(_model).ToNot(BeNil())
 				Expect(err).To(BeNil())
 			})
@@ -24107,6 +24352,16 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(updateExtensionDeploymentOptionsModel.Subsystems).To(Equal([]string{"ltest_0401"}))
 				Expect(updateExtensionDeploymentOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
 			})
+			It(`Invoke NewUpdateLogDataRetentionTagsOptions successfully`, func() {
+				// Construct an instance of the UpdateLogDataRetentionTagsOptions model
+				updateLogDataRetentionTagsOptionsTags := []string{"Short", "Intermediate", "Long"}
+				updateLogDataRetentionTagsOptionsModel := logsService.NewUpdateLogDataRetentionTagsOptions(updateLogDataRetentionTagsOptionsTags)
+				updateLogDataRetentionTagsOptionsModel.SetTags([]string{"Short", "Intermediate", "Long"})
+				updateLogDataRetentionTagsOptionsModel.SetHeaders(map[string]string{"foo": "bar"})
+				Expect(updateLogDataRetentionTagsOptionsModel).ToNot(BeNil())
+				Expect(updateLogDataRetentionTagsOptionsModel.Tags).To(Equal([]string{"Short", "Intermediate", "Long"}))
+				Expect(updateLogDataRetentionTagsOptionsModel.Headers).To(Equal(map[string]string{"foo": "bar"}))
+			})
 			It(`Invoke NewUpdateOutgoingWebhookOptions successfully`, func() {
 				// Construct an instance of the OutgoingWebhooksV1IbmEventNotificationsConfig model
 				outgoingWebhooksV1IbmEventNotificationsConfigModel := new(logsv0.OutgoingWebhooksV1IbmEventNotificationsConfig)
@@ -24161,12 +24416,6 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(quotaV1RuleModel.RuleTypeID).To(Equal(core.StringPtr("includes")))
 				Expect(quotaV1RuleModel.Name).To(Equal(core.StringPtr("Rule Name")))
 
-				// Construct an instance of the QuotaV1ArchiveRetention model
-				quotaV1ArchiveRetentionModel := new(logsv0.QuotaV1ArchiveRetention)
-				Expect(quotaV1ArchiveRetentionModel).ToNot(BeNil())
-				quotaV1ArchiveRetentionModel.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-				Expect(quotaV1ArchiveRetentionModel.ID).To(Equal(CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")))
-
 				// Construct an instance of the QuotaV1LogRules model
 				quotaV1LogRulesModel := new(logsv0.QuotaV1LogRules)
 				Expect(quotaV1LogRulesModel).ToNot(BeNil())
@@ -24182,7 +24431,7 @@ var _ = Describe(`LogsV0`, func() {
 				policyPrototypeModel.Priority = core.StringPtr("type_high")
 				policyPrototypeModel.ApplicationRule = quotaV1RuleModel
 				policyPrototypeModel.SubsystemRule = quotaV1RuleModel
-				policyPrototypeModel.ArchiveRetention = quotaV1ArchiveRetentionModel
+				policyPrototypeModel.ArchiveRetentionTag = core.StringPtr("Default")
 				policyPrototypeModel.Enabled = core.BoolPtr(true)
 				policyPrototypeModel.LogRules = quotaV1LogRulesModel
 				Expect(policyPrototypeModel.Name).To(Equal(core.StringPtr("My Policy")))
@@ -24191,7 +24440,7 @@ var _ = Describe(`LogsV0`, func() {
 				Expect(policyPrototypeModel.Priority).To(Equal(core.StringPtr("type_high")))
 				Expect(policyPrototypeModel.ApplicationRule).To(Equal(quotaV1RuleModel))
 				Expect(policyPrototypeModel.SubsystemRule).To(Equal(quotaV1RuleModel))
-				Expect(policyPrototypeModel.ArchiveRetention).To(Equal(quotaV1ArchiveRetentionModel))
+				Expect(policyPrototypeModel.ArchiveRetentionTag).To(Equal(core.StringPtr("Default")))
 				Expect(policyPrototypeModel.Enabled).To(Equal(core.BoolPtr(true)))
 				Expect(policyPrototypeModel.LogRules).To(Equal(quotaV1LogRulesModel))
 
@@ -29155,6 +29404,24 @@ var _ = Describe(`LogsV0`, func() {
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))
 		})
+		It(`Invoke UnmarshalLogDataRetentionTags successfully`, func() {
+			// Construct an instance of the model.
+			model := new(logsv0.LogDataRetentionTags)
+			model.Tags = []string{"Short", "Intermediate", "Long"}
+
+			b, err := json.Marshal(model)
+			Expect(err).To(BeNil())
+
+			var raw map[string]json.RawMessage
+			err = json.Unmarshal(b, &raw)
+			Expect(err).To(BeNil())
+
+			var result *logsv0.LogDataRetentionTags
+			err = logsv0.UnmarshalLogDataRetentionTags(raw, &result)
+			Expect(err).To(BeNil())
+			Expect(result).ToNot(BeNil())
+			Expect(result).To(Equal(model))
+		})
 		It(`Invoke UnmarshalOutgoingWebhookPrototype successfully`, func() {
 			// Construct an instance of the model.
 			model := new(logsv0.OutgoingWebhookPrototype)
@@ -29225,7 +29492,7 @@ var _ = Describe(`LogsV0`, func() {
 			model.Priority = core.StringPtr("type_high")
 			model.ApplicationRule = nil
 			model.SubsystemRule = nil
-			model.ArchiveRetention = nil
+			model.ArchiveRetentionTag = core.StringPtr("Default")
 			model.Enabled = core.BoolPtr(true)
 			model.LogRules = nil
 
@@ -29238,24 +29505,6 @@ var _ = Describe(`LogsV0`, func() {
 
 			var result *logsv0.PolicyPrototype
 			err = logsv0.UnmarshalPolicyPrototype(raw, &result)
-			Expect(err).To(BeNil())
-			Expect(result).ToNot(BeNil())
-			Expect(result).To(Equal(model))
-		})
-		It(`Invoke UnmarshalQuotaV1ArchiveRetention successfully`, func() {
-			// Construct an instance of the model.
-			model := new(logsv0.QuotaV1ArchiveRetention)
-			model.ID = CreateMockUUID("3dc02998-0b50-4ea8-b68a-4779d716fa1f")
-
-			b, err := json.Marshal(model)
-			Expect(err).To(BeNil())
-
-			var raw map[string]json.RawMessage
-			err = json.Unmarshal(b, &raw)
-			Expect(err).To(BeNil())
-
-			var result *logsv0.QuotaV1ArchiveRetention
-			err = logsv0.UnmarshalQuotaV1ArchiveRetention(raw, &result)
 			Expect(err).To(BeNil())
 			Expect(result).ToNot(BeNil())
 			Expect(result).To(Equal(model))
@@ -31833,7 +32082,7 @@ var _ = Describe(`LogsV0`, func() {
 			model.Priority = core.StringPtr("type_high")
 			model.ApplicationRule = nil
 			model.SubsystemRule = nil
-			model.ArchiveRetention = nil
+			model.ArchiveRetentionTag = core.StringPtr("Default")
 			model.Enabled = core.BoolPtr(true)
 			model.LogRules = nil
 


### PR DESCRIPTION
## PR summary
Add support for tags retention to the TCO policy so that the logs pushed to the cos bucket can have these retention tags attached to them.
Related Work-item - https://github.ibm.com/Observability/dragonlog-cx/issues/2428

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->